### PR TITLE
Us 34 admin invoice show page invoice item information

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -5,5 +5,6 @@ class Admin::InvoicesController < ApplicationController
 
   def show
     @invoice = Invoice.find(params[:id])
+    @invoice_items = @invoice.invoice_items
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,4 +7,8 @@ class InvoiceItem < ApplicationRecord
   validates :status, presence: true
   
   enum status: {"Pending" => 0, "Packaged" => 1, "Shipped" => 2}
+
+  def format_price_sold
+    (self.unit_price.to_f / 100).to_fs(:currency)
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -6,5 +6,5 @@ class InvoiceItem < ApplicationRecord
   validates :unit_price, presence: true, numericality: true
   validates :status, presence: true
   
-  enum status: {"pending" => 0, "packaged" => 1, "shipped" => 2}
+  enum status: {"Pending" => 0, "Packaged" => 1, "Shipped" => 2}
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,4 +1,25 @@
 <h1>Invoice #<%= @invoice.id %></h1>
 <p>Status <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.format_date_created %></p>
-<p>Customer: <%= @invoice.customer.full_name%> </p>
+
+<h3>Customer: <%= @invoice.customer.full_name%> </h3>
+
+<h3>Items on this Invoice:</h3>
+<table>
+  <tr>
+    <th>Item Name</th>
+    <th>Quantity</th>
+    <th>Unit Price</th>
+    <th>Status</th>
+  </tr>
+ <% @invoice_items.each do |invoice_item| %>
+  <div id="invoice_item-<%=invoice_item.id %>">
+    <tr>
+      <td><%= invoice_item.item.name %></td>
+      <td><%= invoice_item.quantity %></td>
+      <td><%= invoice_item.format_price_sold %></td>
+      <td><%= invoice_item.status %></td>
+    </tr>
+    <% end %>
+  </div>
+ </table>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -3,11 +3,25 @@ require "rails_helper"
 RSpec.describe "Admin Invoices Show", type: :feature do
   describe "As a admin" do
     before do
+      @merchant_1 = create(:merchant)
+
+      @item_1 = create(:item, name: "shoes", merchant: @merchant_1)
+      @item_2 = create(:item, name: "books", merchant: @merchant_1)
+      @item_3 = create(:item, name: "lamp", merchant: @merchant_1)
+
       @customer_1 = Customer.create!(first_name: "Lance", last_name: "B")
       @customer_2 = Customer.create!(first_name: "Jess", last_name: "K")
 
       @invoice_1 = @customer_1.invoices.create!(status: 1, created_at: "2011-09-13")
       @invoice_2 = @customer_2.invoices.create!(status: 2, created_at: "2022-03-08")
+
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 2500, status: 0) # pending
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 2, unit_price: 1000, status: 1) # packaged
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 100000, status: 2) # shipped
+
+      # unit_price
+        # price sold at -> invoice_items
+        # current sales price -> item
     end
 
     describe "User Story 33 - Admin Invoice Show page" do
@@ -27,6 +41,31 @@ RSpec.describe "Admin Invoices Show", type: :feature do
 
         expect(page).to have_content("Lance B")
         expect(page).to_not have_content("Jess K")
+      end
+    end
+
+    describe "User Story 34 - Invoice Item Information" do
+      it "lists invoice's items and their info" do
+        within "#item-#{@item_1.id}" do
+          expect(page).to have_content("shoes")   # item name
+          expect(page).to have_content("1")       # quantity ordered
+          expect(page).to have_content("$15")     # sold at
+          expect(page).to have_content("Pending") # status
+        end
+
+        within "#item-#{@item_2.id}" do
+          expect(page).to have_content("shoes")
+          expect(page).to have_content("2")
+          expect(page).to have_content("$15")
+          expect(page).to have_content("Pending")
+        end
+
+        within "#item-#{@item_3.id}" do
+          expect(page).to have_content("shoes")
+          expect(page).to have_content("3")
+          expect(page).to have_content("$15")
+          expect(page).to have_content("Pending")
+        end
       end
     end
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin Invoices Show", type: :feature do
       @merchant_1 = create(:merchant)
 
       @item_1 = create(:item, name: "shoes", merchant: @merchant_1)
-      @item_2 = create(:item, name: "books", merchant: @merchant_1)
+      @item_2 = create(:item, name: "book", merchant: @merchant_1)
       @item_3 = create(:item, name: "lamp", merchant: @merchant_1)
 
       @customer_1 = Customer.create!(first_name: "Lance", last_name: "B")
@@ -16,18 +16,14 @@ RSpec.describe "Admin Invoices Show", type: :feature do
       @invoice_2 = @customer_2.invoices.create!(status: 2, created_at: "2022-03-08")
 
       @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 2500, status: 0) # pending
-      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 2, unit_price: 1000, status: 1) # packaged
-      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 5000, status: 2) # shipped
+      @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, quantity: 2, unit_price: 1000, status: 1) # packaged
+      @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 5000, status: 2) # shipped
 
-      # unit_price
-        # price sold at -> invoice_items
-        # current sales price -> item
+      visit admin_invoice_path(@invoice_1)
     end
 
     describe "User Story 33 - Admin Invoice Show page" do
       it "list invoice attributes" do
-        visit admin_invoice_path(@invoice_1)
-
         expect(page).to have_content(@invoice_1.id)
         expect(page).to have_content("Completed")
         expect(page).to have_content("Tuesday, September 13, 2011")
@@ -37,8 +33,6 @@ RSpec.describe "Admin Invoices Show", type: :feature do
       end
 
       it "has customers first and last name" do
-        visit admin_invoice_path(@invoice_1)
-
         expect(page).to have_content("Lance B")
         expect(page).to_not have_content("Jess K")
       end
@@ -46,25 +40,25 @@ RSpec.describe "Admin Invoices Show", type: :feature do
 
     describe "User Story 34 - Invoice Item Information" do
       it "lists invoice's items and their info" do
-        within "#item-#{@item_1.id}" do
-          expect(page).to have_content("shoes")   # item name
-          expect(page).to have_content("1")       # quantity ordered
-          expect(page).to have_content("$25.00")     # sold at
-          expect(page).to have_content("Pending") # status
+        within "#invoice_item-#{@invoice_item_1.id}" do
+          expect(page).to have_content("shoes")
+          expect(page).to have_content("1")
+          expect(page).to have_content("$25.00")
+          expect(page).to have_content("Pending")
         end
 
-        within "#item-#{@item_2.id}" do
-          expect(page).to have_content("shoes")
+        within "#invoice_item-#{@invoice_item_2.id}" do
+          expect(page).to have_content("book")
           expect(page).to have_content("2")
           expect(page).to have_content("$10.00")
-          expect(page).to have_content("Pending")
+          expect(page).to have_content("Packaged")
         end
 
-        within "#item-#{@item_3.id}" do
-          expect(page).to have_content("shoes")
+        within "#invoice_item-#{@invoice_item_3.id}" do
+          expect(page).to have_content("lamp")
           expect(page).to have_content("3")
           expect(page).to have_content("$50.00")
-          expect(page).to have_content("Pending")
+          expect(page).to have_content("Shipped")
         end
       end
     end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Admin Invoices Show", type: :feature do
 
       @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 2500, status: 0) # pending
       @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 2, unit_price: 1000, status: 1) # packaged
-      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 100000, status: 2) # shipped
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 5000, status: 2) # shipped
 
       # unit_price
         # price sold at -> invoice_items
@@ -49,21 +49,21 @@ RSpec.describe "Admin Invoices Show", type: :feature do
         within "#item-#{@item_1.id}" do
           expect(page).to have_content("shoes")   # item name
           expect(page).to have_content("1")       # quantity ordered
-          expect(page).to have_content("$15")     # sold at
+          expect(page).to have_content("$25.00")     # sold at
           expect(page).to have_content("Pending") # status
         end
 
         within "#item-#{@item_2.id}" do
           expect(page).to have_content("shoes")
           expect(page).to have_content("2")
-          expect(page).to have_content("$15")
+          expect(page).to have_content("$10.00")
           expect(page).to have_content("Pending")
         end
 
         within "#item-#{@item_3.id}" do
           expect(page).to have_content("shoes")
           expect(page).to have_content("3")
-          expect(page).to have_content("$15")
+          expect(page).to have_content("$50.00")
           expect(page).to have_content("Pending")
         end
       end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -9,11 +9,29 @@ RSpec.describe InvoiceItem, type: :model do
     it { should validate_numericality_of :unit_price}
     
     it { should validate_presence_of :status}
-    it { should define_enum_for(:status).with_values("pending" => 0, "packaged" => 1, "shipped" => 2)}
+    it { should define_enum_for(:status).with_values("Pending" => 0, "Packaged" => 1, "Shipped" => 2)}
   end
-
+  
   describe "relationships" do
     it {should belong_to :invoice}
     it {should belong_to :item}
+  end
+
+  before do
+    @merchant_1 = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant_1)
+    @item_2 = create(:item, merchant: @merchant_1)
+    @customer_1 = create(:customer)
+    @invoice_1 = create(:invoice, customer: @customer_1)
+    @invoice_2 = create(:invoice, customer: @customer_1)
+    @invoice_item_1 = create(:invoice_item, item: @item_1, invoice: @invoice_1, unit_price: 500)
+    @invoice_item_2 = create(:invoice_item, item: @item_2, invoice: @invoice_2, unit_price: 1027)
+  end
+
+  describe "instance methods" do
+    it "formats unit_price sold at" do
+      expect(@invoice_item_1.format_price_sold).to eq("$5.00")
+      expect(@invoice_item_2.format_price_sold).to eq("$10.27")
+    end
   end
 end


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Test
- [ ] Refactor/Style

## Description
Relevant User Story(s): 34

Admin Invoice Show Page - display invoice items' information. 

Additional Notes:
- InvoiceItem enum keys update to show up on view page properly ("shipped" -> "Shipped")
- `format_price_sold` InvoiceItem model method created to format sold unit_price (500 -> $5.00)
- 100% model and feature test coverage per simplecov

## Implements/Fixes Issue(s):
closes #35 

## Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
*Description of problem(s)*

## Any Fun Facts or Gifs You Want to Add to This PR?
In 1987, American Airlines saved $40,000 annually by removing one olive from their first class salads.