### PR TITLE
Create update item link on Merchant Item Show

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -5,6 +5,7 @@ class Merchant::ItemsController < ApplicationController
   end
 
   def show
+    @merchant = Merchant.find(params[:merchant_id])
     @item = Item.find(params[:id])
   end
 
@@ -24,6 +25,7 @@ class Merchant::ItemsController < ApplicationController
   end
 
   def edit
+    @merchant = Merchant.find(params[:merchant_id])
     @item = Item.find(params[:id])
   end
 

--- a/app/views/merchant/items/show.html.erb
+++ b/app/views/merchant/items/show.html.erb
@@ -2,3 +2,5 @@
 <p>Description: <%= @item.description %></p>
 <p>Current selling price: <%= @item.format_unit_price %></p>
 <p>Merchant ID: <%= @item.merchant_id %></p>
+
+<%= link_to "Update Item", edit_merchant_item_path(@merchant, @item) %>

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -55,5 +55,14 @@ RSpec.describe "Merchant Item Show" do
       expect(page).to have_content("Merchant ID: #{@merchant_1.id}")
     end
   end
+
+  describe "User Story 8 - Merchant Item Update Link" do
+    it "has link to update item's information" do
+      expect(page).to have_link("Update Item")
+
+      click_on "Update Item"
+      expect(page.current_path).to eq(edit_merchant_item_path(@merchant_1, @item_1))
+    end
+  end
 end
 


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Test
- [ ] Refactor/Style

## Description
Relevant User Story(s): 8

Noticed us-8's "Update Item" link on the Merchant Item Show Page was missing.
All tests pass. Coverage still 100%. Feature works fine on the local rails server.

## Implements/Fixes Issue(s):
Missing page link.

## Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
*Description of problem(s)*

## Any Fun Facts or Gifs You Want to Add to This PR?
.sdrawkcab si ecnetnes sihT