### PR TITLE
Delete bulk discounts

### DIFF
--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -24,6 +24,12 @@ class Merchant::BulkDiscountsController < ApplicationController
     @bulk_discount = BulkDiscount.find(params[:id])
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    BulkDiscount.find(params[:id]).destroy
+    redirect_to merchant_bulk_discounts_path(@merchant)
+  end
+
   private
   def bulk_discount_params
     params.require(:bulk_discount).permit(:discount, :quantity)

--- a/app/views/merchant/bulk_discounts/index.html.erb
+++ b/app/views/merchant/bulk_discounts/index.html.erb
@@ -4,6 +4,7 @@
 
 <% @bulk_discounts.each do |bulk_discount| %>
   <div id="bulk_discount-<%=bulk_discount.id%>">
-    <p><%= link_to "Bulk Discount #{bulk_discount.id}", merchant_bulk_discount_path(@merchant, bulk_discount) %> is <%= bulk_discount.discount %>% off <%= bulk_discount.quantity %> items</p>
+    <p><%= link_to "Bulk Discount #{bulk_discount.id}", merchant_bulk_discount_path(@merchant, bulk_discount) %> is <%= bulk_discount.discount %>% off <%= bulk_discount.quantity %> items
+    <%= button_to "Delete", merchant_bulk_discount_path(@merchant, bulk_discount), method: :delete %></p>
   </div>
 <% end %>

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -3,11 +3,21 @@ require "rails_helper"
 RSpec.describe "Merchant's Bulk Discounts Index", type: :feature do
   describe "when merchant visits" do
     let!(:merchant_1) {create(:merchant)}
+    let!(:merchant_2) {create(:merchant)}
     let!(:bulk_discount_1) {merchant_1.bulk_discounts.create!(discount: 20, quantity: 10)}
     let!(:bulk_discount_2) {merchant_1.bulk_discounts.create!(discount: 15, quantity: 15)}
+    let!(:bulk_discount_3) {merchant_2.bulk_discounts.create!(discount: 15, quantity: 15)}
 
     before do
         visit merchant_bulk_discounts_path(merchant_1)
+    end
+
+    describe "displays bulk discounts" do
+      it "only displays discount's for that merchant" do
+        expect(page).to have_css("#bulk_discount-#{bulk_discount_1.id}")
+        expect(page).to have_css("#bulk_discount-#{bulk_discount_2.id}")
+        expect(page).to_not have_css("#bulk_discount-#{bulk_discount_3.id}")
+      end
     end
 
     describe "displays bulk discounts w/their attributes" do

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -70,5 +70,25 @@ RSpec.describe "Merchant's Bulk Discounts Index", type: :feature do
         expect(current_path).to eq("/merchants/#{merchant_1.id}/bulk_discounts/new")
       end
     end
+
+    describe "displays option to delete bulk discounts" do
+      it "delete button next to each discount" do
+        within "#bulk_discount-#{bulk_discount_1.id}" do
+          expect(page).to have_button("Delete", count: 1)
+        end
+
+        within "#bulk_discount-#{bulk_discount_2.id}" do
+          expect(page).to have_button("Delete", count: 1)
+        end
+      end
+
+      it "clicking 'delete' reloads the page without the deleted item" do
+        click_on "Delete", match: :first
+
+        expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1))
+        expect(page).to_not have_content("20% off 10 items")
+        expect(page).to have_no_link("Bulk Discount #{bulk_discount_1.id}", href: merchant_bulk_discount_path(merchant_1, bulk_discount_1))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Test
- [ ] Refactor/Style

## Description
Relevant User Story(s): 3

Merchant can delete a bulk discount on their discount index page.

## Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally